### PR TITLE
Veritone changes for CIS hardening

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ partitioning: True
 use_aide: True
 
 # Section 01 Level 4
-set_bootloader_password: false
+set_bootloader_password: True
 grub_superuser: root
 # Grub Bootloader PBKDF2 Password (use grub-mkpasswd-pbkdf2 to generate): "password"
 root_password_grub: grub.pbkdf2.sha512.10000.2EDB88EB8D897897A67D45961EFACF9878E3280CC9FCE3BD0035D0F789409BC698831ED38349DF008FC9B1FCF56B26997BB802ED0299B0480744DD45C8658F18.516ABD49F2E70BF3EE21D02B5F6FBFBDC47C056B4CC8FEF2AB83E5F0997C1B00963E11A2B83533D892B3D64FDA2A065AF966D92F029402CB5E3BFD3776FE3D0C 
@@ -52,8 +52,8 @@ enable_tcp_syncookies: True
 disable_ipv6: True
 
 # Section 03 Level 4
-enable_hosts_allow: False
-enable_hosts_deny: False
+enable_hosts_allow: True
+enable_hosts_deny: True
 
 # Section 03 Level 6
 activate_iptables: True
@@ -81,11 +81,11 @@ restrict_core_dumps: True
 
 # Section 05
 # Section 05 Level 2
-permit_root_login: without-password
-sshd_allow_users: sshuser
-sshd_allow_groups: sshusersallow
-sshd_deny_users: sshdenied
-sshd_deny_groups: sshusersdeny
+permit_root_login: no
+sshd_allow_users: ubuntu
+sshd_allow_groups: 
+sshd_deny_users: 
+sshd_deny_groups: 
 
 # Section 06
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ disable_wifi: True
 # Section 04 Level 1
 enable_auditd: True
 # Set auditd logs file size in /var/log/auditd
-max_log_file_auditd: 200
+max_log_file_auditd: 32
 
 # Section 4 Level 2
 set_rsyslog_remote: True

--- a/tasks/check_requirements.yml
+++ b/tasks/check_requirements.yml
@@ -2,5 +2,7 @@
 
   - name: Check if OS is Ubuntu 16.04 xenial (we do not support others)
     debug: msg="Check OS"
-    failed_when: ansible_distribution != "Ubuntu" and ansible_distribution_version | version_compare('16.04', '>=')
+    failed_when: ansible_distribution != "Ubuntu"
+                  and 
+                ansible_distribution_major_version == "16"
 

--- a/tasks/check_requirements.yml
+++ b/tasks/check_requirements.yml
@@ -3,6 +3,6 @@
   - name: Check if OS is Ubuntu 16.04 xenial (we do not support others)
     debug: msg="Check OS"
     failed_when: ansible_distribution != "Ubuntu"
-                  and 
+                  and
                 ansible_distribution_major_version == "16"
 

--- a/tasks/check_requirements.yml
+++ b/tasks/check_requirements.yml
@@ -2,5 +2,5 @@
 
   - name: Check if OS is Ubuntu 16.04 xenial (we do not support others)
     debug: msg="Check OS"
-    failed_when: ansible_distribution != "Ubuntu" and ansible_distribution_version !="16.04"
+    failed_when: ansible_distribution != "Ubuntu" and ansible_distribution_version | version_compare('16.04', '>=')
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 
-  - include: check_requirements.yml
+  - include_tasks: check_requirements.yml
 
-  - include: section_01.yml
+  - include_tasks: section_01.yml
     tags: section01
 
-  - include: section_02.yml
+  - include_tasks: section_02.yml
     tags: section02
 
-  - include: section_03.yml
+  - include_tasks: section_03.yml
     tags: section03
 
-  - include: section_04.yml
+  - include_tasks: section_04.yml
     tags: section04
 
-  - include: section_05.yml
+  - include_tasks: section_05.yml
     tags: section05
 
-  - include: section_06.yml
+  - include_tasks: section_06.yml
     tags: section06

--- a/tasks/section_01.yml
+++ b/tasks/section_01.yml
@@ -1,41 +1,41 @@
 ---
 
-  - include: section_01_level1.yml
+  - include_tasks: section_01_level1.yml
     tags:
       - section01
       - level1
 
-  - include: section_01_level2.yml
+  - include_tasks: section_01_level2.yml
     tags:
       - section01
       - level2
 
-  - include: section_01_level3.yml
+  - include_tasks: section_01_level3.yml
     tags:
       - section01
       - level3
 
-  - include: section_01_level4.yml
+  - include_tasks: section_01_level4.yml
     tags:
       - section01
       - level4
 
-  - include: section_01_level5.yml
+  - include_tasks: section_01_level5.yml
     tags:
       - section01
       - level5
 
-  - include: section_01_level6.yml
+  - include_tasks: section_01_level6.yml
     tags:
       - section01
       - level6
 
-  - include: section_01_level7.yml
+  - include_tasks: section_01_level7.yml
     tags:
       - section01
       - level7
 
-  - include: section_01_level8.yml
+  - include_tasks: section_01_level8.yml
     tags:
       - section01
       - level8

--- a/tasks/section_01_level3.yml
+++ b/tasks/section_01_level3.yml
@@ -16,7 +16,7 @@
       name: "Check files integrity"
       minute: 0
       hour: 5
-      job: "/usr/sbin/aide --check"
+      job: "/usr/bin/aide --check"
     when: use_aide == True
     tags:
       - section1

--- a/tasks/section_01_level4.yml
+++ b/tasks/section_01_level4.yml
@@ -5,7 +5,7 @@
       dest: /boot/grub/grub.cfg
       owner: root
       group: root
-      mode: 0600
+      mode: "og-rwx"
     tags:
       - section1
       - section1.4

--- a/tasks/section_02.yml
+++ b/tasks/section_02.yml
@@ -1,16 +1,16 @@
 ---
 
-  - include: section_02_level1.yml
+  - include_tasks: section_02_level1.yml
     tags:
       - section02
       - level1
 
-  - include: section_02_level2.yml
+  - include_tasks: section_02_level2.yml
     tags:
       - section02
       - level2
 
-  - include: section_02_level3.yml
+  - include_tasks: section_02_level3.yml
     tags:
       - section02
       - level3

--- a/tasks/section_02_level2.yml
+++ b/tasks/section_02_level2.yml
@@ -32,7 +32,7 @@
       regexp: '{{item.expression}}'
       line: '{{item.value}}'
     with_items:
-      - { name: '/etc/chrony/chrony.conf', expression: '^server', value: 'server 10.190.14.12' }
+      - { name: '/etc/chrony/chrony.conf', expression: '^server', value: 'server 192.168.0.1' }
       - { name: '/etc/chrony/chrony.conf', expression: '^pool', value: '' }
     when: ntp_package  == "chrony"
     notify: restart chrony

--- a/tasks/section_02_level2.yml
+++ b/tasks/section_02_level2.yml
@@ -159,6 +159,19 @@
       - section2.2
       - section2.2.7
 
+  - name: 2.2.7 Ensure NFS is not enabled (Scored)
+    service:
+      name: "{{ item }}"
+      state: stopped
+      enabled: no
+    with_items:
+      - nfs-server
+    when: nfs_installed.rc == 0
+    tags:
+      - section2
+      - section2.2
+      - section2.2.7
+
   - command: dpkg-query -s rpcbind
     register: rpcbind_installed
     failed_when: False
@@ -169,15 +182,14 @@
       - section2.2
       - section2.2.7
 
-  - name: 2.2.7 Ensure NFS and RPC are not enabled (Scored)
+  - name: 2.2.7 Ensure RPC is not enabled (Scored)
     service:
       name: "{{ item }}"
       state: stopped
       enabled: no
     with_items:
       - rpcbind
-      - nfs-server
-    when: rpcbind_installed.rc == 0 or nfs_installed.rc == 0
+    when: rpcbind_installed.rc == 0
     tags:
       - section2
       - section2.2
@@ -235,12 +247,33 @@
       - section2.2
       - section2.2.10
 
-  - name: 2.2.10 Ensure HTTP server is not enabled (Scored)
+  - name: 2.2.10 Ensure Apache HTTP server is not enabled (Scored)
     service:
       name: apache2
       state: stopped
       enabled: no
     when: apache2_installed.rc == 0
+    tags:
+      - section2
+      - section2.2
+      - section2.2.10
+
+  - command: dpkg-query -s nginx
+    register: nginx_installed
+    failed_when: False 
+    ignore_errors: True
+    changed_when: False
+    tags:
+      - section2
+      - section2.2
+      - section2.2.10
+
+  - name: 2.2.10 Ensure Nginx HTTP server is not enabled (Scored)
+    service:
+      name: nginx
+      state: stopped
+      enabled: no
+    when: nginx_installed.rc == 0
     tags:
       - section2
       - section2.2

--- a/tasks/section_02_level3.yml
+++ b/tasks/section_02_level3.yml
@@ -34,6 +34,7 @@
     apt:
       name: telnet
       state: absent
+      purge: True
     tags:
       - section2
       - section2.3

--- a/tasks/section_03.yml
+++ b/tasks/section_03.yml
@@ -1,36 +1,36 @@
 ---
 
-  - include: section_03_level1.yml
+  - include_tasks: section_03_level1.yml
     tags:
       - section03
       - level1
 
-  - include: section_03_level2.yml
+  - include_tasks: section_03_level2.yml
     tags:
       - section03
       - level2
 
-  - include: section_03_level3.yml
+  - include_tasks: section_03_level3.yml
     tags:
       - section03
       - level3
 
-  - include: section_03_level4.yml
+  - include_tasks: section_03_level4.yml
     tags:
       - section03
       - level4
 
-  - include: section_03_level5.yml
+  - include_tasks: section_03_level5.yml
     tags:
       - section03
       - level5
 
-  - include: section_03_level6.yml
+  - include_tasks: section_03_level6.yml
     tags:
       - section03
       - level6
 
-  - include: section_03_level7.yml
+  - include_tasks: section_03_level7.yml
     tags:
       - section03
       - level7

--- a/tasks/section_03_level1.yml
+++ b/tasks/section_03_level1.yml
@@ -12,7 +12,7 @@
 
   - name: 3.1.2 Ensure packet redirect sending is disabled (Scored)
     sysctl:
-      name: net.ipv4.conf.all.send_redirects
+      name: "{{ item }}"
       value: 0
       sysctl_set: True
       state: present

--- a/tasks/section_03_level1.yml
+++ b/tasks/section_03_level1.yml
@@ -14,7 +14,11 @@
     sysctl:
       name: net.ipv4.conf.all.send_redirects
       value: 0
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv4.conf.all.send_redirects
+      - net.ipv4.conf.default.send_redirects
     tags:
       - section3
       - section3.1

--- a/tasks/section_03_level2.yml
+++ b/tasks/section_03_level2.yml
@@ -2,9 +2,13 @@
 
   - name: 3.2.1 Ensure source routed packets are not accepted (Scored)
     sysctl:
-      name: net.ipv4.conf.all.accept_source_route
+      name: "{{ item }}"
       value: 0
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv4.conf.all.accept_source_route
+      - net.ipv4.conf.default.accept_source_route
     tags:
       - section3
       - section3.2
@@ -12,9 +16,13 @@
 
   - name: 3.2.2 Ensure ICMP redirects are not accepted (Scored)
     sysctl:
-      name: net.ipv4.conf.all.accept_redirects
+      name: "{{ item }}"
       value: 0
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv4.conf.all.accept_redirects
+      - net.ipv4.conf.default.accept_redirects
     tags:
       - section3
       - section3.2
@@ -22,9 +30,13 @@
 
   - name: 3.2.3 Ensure secure ICMP redirects are not accepted (Scored)
     sysctl:
-      name: net.ipv4.conf.all.secure_redirects
+      name: "{{ item }}"
       value: 0
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv4.conf.all.secure_redirects
+      - net.ipv4.conf.default.secure_redirects
     tags:
       - section3
       - section3.2
@@ -32,9 +44,13 @@
 
   - name: 3.2.4 Ensure suspicious packets are logged (Scored)
     sysctl:
-      name: net.ipv4.conf.all.log_martians
+      name: "{{ item }}"
       value: 1
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv4.conf.all.log_martians
+      - net.ipv4.conf.default.log_martians
     tags:
       - section3
       - section3.2
@@ -62,9 +78,13 @@
 
   - name: 3.2.7 Ensure Reverse Path Filtering is enabled (Scored)
     sysctl:
-      name: net.ipv4.conf.all.rp_filter
+      name: "{{ item }}"
       value: 1
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv4.conf.all.rp_filter
+      - net.ipv4.conf.default.rp_filter
     tags:
       - section3
       - section3.2

--- a/tasks/section_03_level3.yml
+++ b/tasks/section_03_level3.yml
@@ -2,9 +2,13 @@
 
   - name: 3.3.1 Ensure IPv6 router advertisements are not accepted (Not Scored)
     sysctl:
-      name: net.ipv6.conf.all.accept_ra
+      name: "{{ item }}"
       value: 0
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv6.conf.all.accept_ra
+      - net.ipv6.conf.default.accept_ra 
     tags:
       - section3
       - section3.3
@@ -12,9 +16,13 @@
 
   - name: 3.3.2 Ensure IPv6 redirects are not accepted (Not Scored)
     sysctl:
-      name: net.ipv6.conf.default.accept_redirects
+      name: "{{ item }}"
       value: 0
+      sysctl_set: True
       state: present
+    with_items:
+      - net.ipv6.conf.default.accept_redirects
+      - net.ipv6.conf.all.accept_redirects
     tags:
       - section3
       - section3.3

--- a/tasks/section_03_level3.yml
+++ b/tasks/section_03_level3.yml
@@ -29,14 +29,9 @@
       - section3.3.2
 
   - name: 3.3.3 Ensure IPv6 is disabled (Not Scored)
-    sysctl:
-      name: "{{ item }}"
-      value: 1
-      state: present
-    with_items:
-      - net.ipv6.conf.all.disable_ipv6
-      - net.ipv6.conf.default.disable_ipv6
-      - net.ipv6.conf.lo.disable_ipv6
+    lineinfile:
+      dest: /etc/default/grub
+      line: "GRUB_CMDLINE_LINUX='ipv6.disable=1'"
     when: disable_ipv6 == True
     tags:
       - section3

--- a/tasks/section_03_level4.yml
+++ b/tasks/section_03_level4.yml
@@ -12,7 +12,7 @@
   - name: 3.4.2 Ensure /etc/hosts.allow is configured (Scored)
     lineinfile:
       dest: /etc/hosts.allow
-      line: 'ALL:ALL'
+      line: 'ALL:172.31.0.0/255.255.240.0'
     when: enable_hosts_allow == True
     tags:
       - section3

--- a/tasks/section_04.yml
+++ b/tasks/section_04.yml
@@ -1,16 +1,16 @@
 ---
 
-  - include: section_04_level1.yml
+  - include_tasks: section_04_level1.yml
     tags:
       - section04
       - level1
 
-  - include: section_04_level2.yml
+  - include_tasks: section_04_level2.yml
     tags:
       - section04
       - level2
 
-  - include: section_04_level3.yml
+  - include_tasks: section_04_level3.yml
     tags:
       - section04
       - level3

--- a/tasks/section_04_level1.yml
+++ b/tasks/section_04_level1.yml
@@ -53,6 +53,7 @@
     service:
         name: auditd
         enabled: yes
+        state: reloaded
     when: enable_auditd == True
     tags:
       - section4

--- a/tasks/section_04_level2.yml
+++ b/tasks/section_04_level2.yml
@@ -224,7 +224,11 @@
       - section4.2.2.5
 
   - name: 4.2.4 Ensure permissions on all logfiles are configured (Scored)
-    shell: chmod -R g-wx,o-rwx /var/log/*
+    file:
+      path: /var/log
+      mode: "g-wx,o-rwx"
+      state: directory
+      recurse: True
     tags:
       - section4
       - section4.2

--- a/tasks/section_05.yml
+++ b/tasks/section_05.yml
@@ -1,31 +1,31 @@
 ---
 
-- include: section_05_level1.yml
+- include_tasks: section_05_level1.yml
   tags:
   - section05
   - level1
 
-- include: section_05_level2.yml
+- include_tasks: section_05_level2.yml
   tags:
   - section05
   - level2
 
-- include: section_05_level3.yml
+- include_tasks: section_05_level3.yml
   tags:
   - section05
   - level3
 
-- include: section_05_level4.yml
+- include_tasks: section_05_level4.yml
   tags:
   - section05
   - level4
 
-- include: section_05_level5.yml
+- include_tasks: section_05_level5.yml
   tags:
   - section05
   - level5
 
-- include: section_05_level6.yml
+- include_tasks: section_05_level6.yml
   tags:
   - section05
   - level6

--- a/tasks/section_05_level1.yml
+++ b/tasks/section_05_level1.yml
@@ -67,7 +67,7 @@
 
   - name: 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
     file:
-      path: /etc/cron.monthly
+      path: /etc/cron.d
       state: directory
       owner: root
       group: root

--- a/tasks/section_05_level2.yml
+++ b/tasks/section_05_level2.yml
@@ -83,7 +83,9 @@
     lineinfile:
       dest: /etc/ssh/sshd_config
       regexp: '^PermitRootLogin'
-      line: 'PermitRootLogin {{ permit_root_login }}'
+      line: 'PermitRootLogin no'
+      backup: True
+      validate: '/usr/sbin/sshd -t -f %s'
     notify: restart ssh
     tags:
       - section5

--- a/tasks/section_05_level3.yml
+++ b/tasks/section_05_level3.yml
@@ -50,6 +50,7 @@
       name: /etc/pam.d/common-password
       regexp: '^password\s+sufficient\s+pam_unix.so'
       line: 'password sufficient pam_unix.so remember=5'
+      create: True
     tags:
       - section5
       - section5.3

--- a/tasks/section_05_level4.yml
+++ b/tasks/section_05_level4.yml
@@ -73,8 +73,9 @@
   - name: 5.4.1.4 Ensure inactive password lock is 30 days or less (Scored)
     lineinfile:
       dest: /etc/login.defs
-      line: 'INACTIVE=35'
+      line: 'INACTIVE=30'
       state: present
+      create: True
     when: lock_inactive_rc.rc == 1
     tags:
       - section5

--- a/tasks/section_06.yml
+++ b/tasks/section_06.yml
@@ -1,11 +1,11 @@
 ---
 
-- include: section_06_level1.yml
+- include_tasks: section_06_level1.yml
   tags:
   - section06
   - level1
 
-- include: section_06_level2.yml
+- include_tasks: section_06_level2.yml
   tags:
   - section06
   - level2

--- a/tasks/section_06_level1.yml
+++ b/tasks/section_06_level1.yml
@@ -52,9 +52,9 @@
   - name: 6.1.5 Ensure permissions on /etc/gshadow are configured (Scored)
     file:
       path: /etc/gshadow
-      mode: 0640
+      mode: 'o-rwx,g-rw'
       owner: root
-      group: root
+      group: shadow
     tags:
       - section6
       - section6.1


### PR DESCRIPTION
I forked this Ansible role from https://github.com/grupoversia/cis-ubuntu-ansible. It was marked as ready for Ubuntu 16.04.

I made some simple commits to fix a bunch of Ansible 2.4 deprecations and to add a check for Nginx under the HTTP rule. I have been using Nginx forever, so I never presume the only Web server in use is Apache.

I left two deprecation warnings in place because the Ansible modules don't support what the role is trying to do.

Rule 1.1.3 - cannot use the mount module because it does not support mounting with no device, which is what the rule does.

Rule 1.6.2.1 - cannot use the lineinfile module because it notoriously bad at performing multiple changes and that is what the role is using sed for.

@tamsky @anitaj-vt
