### PR TITLE
Monthly scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,8 @@ target/
 *.swp
 site/
 
+# Intellij
 .idea
+
+#Vagrant
+.vagrant

--- a/roles/cis/defaults/main.yml
+++ b/roles/cis/defaults/main.yml
@@ -58,7 +58,7 @@ enable_hosts_deny: False
 # Section 03 Level 6
 activate_iptables: False
 iptables_rules_file: /etc/iptables/rules.v4
-firewall_policy_drop: True
+firewall_policy_drop: False
 
 # Section 03 Level 7
 disable_wifi: True
@@ -82,7 +82,7 @@ restrict_core_dumps: True
 # Section 05
 # Section 05 Level 2
 permit_root_login: no
-sshd_allow_users:
+sshd_allow_users: ubuntu
 sshd_allow_groups: 
 sshd_deny_users: 
 sshd_deny_groups: 
@@ -101,3 +101,10 @@ modify_user_homes: True
 # Section 06 Level 5
 # Default ntp server for when none-already exists.
 ntp_server: 192.168.112.1
+
+### Veritone Control Variables
+
+# These affect Packer builds
+vt_control_5_2_7: False
+vt_control_5_2_9: False
+vt_control_5_2_14: True

--- a/roles/cis/tasks/section_05_level2.yml
+++ b/roles/cis/tasks/section_05_level2.yml
@@ -68,17 +68,17 @@
       - section5.2
       - section5.2.6
 
-        # Rick - Another possible Packer blocker
-        #- name: 5.2.7 Ensure SSH HostbasedAuthentication is disabled (Scored)
-        #lineinfile:
-        #dest: /etc/ssh/sshd_config
-        #regexp: '^HostbasedAuthentication'
-        #line: 'HostbasedAuthentication no'
-        #notify: restart ssh
-        #tags:
-        #- section5
-        #- section5.2
-        #- section5.2.7
+  - name: 5.2.7 Ensure SSH HostbasedAuthentication is disabled (Scored)
+    lineinfile:
+      dest: /etc/ssh/sshd_config
+      regexp: '^HostbasedAuthentication'
+      line: 'HostbasedAuthentication no'
+      notify: restart ssh
+    when: vt_control_5_2_7 | bool
+    tags:
+      - section5
+      - section5.2
+      - section5.2.7
 
   - name: 5.2.8 Ensure SSH root login is disabled (Scored)
     lineinfile:
@@ -93,17 +93,17 @@
       - section5.2
       - section5.2.8
 
-        # Rick - second audit that was preventing Packer access
-        #- name: 5.2.9 Ensure SSH PermitEmptyPasswords is disabled (Scored)
-        #lineinfile:
-        #dest: /etc/ssh/sshd_config
-        #regexp: '^PermitEmptyPasswords'
-        #line: 'PermitEmptyPasswords no'
-        #notify: restart ssh
-        #tags:
-        #- section5
-        #- section5.2
-        #- section5.2.9
+  - name: 5.2.9 Ensure SSH PermitEmptyPasswords is disabled (Scored)
+    lineinfile:
+      dest: /etc/ssh/sshd_config
+      regexp: '^PermitEmptyPasswords'
+      line: 'PermitEmptyPasswords no'
+    when: vt_control_5_2_9 | bool
+    notify: restart ssh
+    tags:
+      - section5
+      - section5.2
+      - section5.2.9
 
   - name: 5.2.10 Ensure SSH PermitUserEnvironment is disabled (Scored)
     lineinfile:
@@ -151,22 +151,22 @@
       - section5.2
       - section5.2.13
 
-        # Rick - Removed on 2/2/2018 to allow Packer to function
-        #- name: 5.2.14 Ensure SSH access is limited (Scored)
-        #lineinfile:
-        #dest: /etc/ssh/sshd_config
-        #regexp: '^{{item.name}}'
-        #line: '{{item.name}} {{item.value}}'
-        #with_items:
-        #- { name: 'AllowUsers' , value: '{{ sshd_allow_users }}' }
-        #- { name: 'AllowGroups' , value: '{{ sshd_allow_groups }}' }
-        #- { name: 'DenyUsers' , value: '{{ sshd_deny_users }}' }
-        #- { name: 'DenyGroups' , value: '{{ sshd_deny_groups }}' }
-        #notify: restart ssh
-        #tags:
-        #- section5
-        #- section5.2
-        #- section5.2.14
+  - name: 5.2.14 Ensure SSH access is limited (Scored)
+    lineinfile:
+      dest: /etc/ssh/sshd_config
+      regexp: '^{{item.name}}'
+      line: '{{item.name}} {{item.value}}'
+    with_items:
+      - { name: 'AllowUsers' , value: '{{ sshd_allow_users }}' }
+      - { name: 'AllowGroups' , value: '{{ sshd_allow_groups }}' }
+      - { name: 'DenyUsers' , value: '{{ sshd_deny_users }}' }
+      - { name: 'DenyGroups' , value: '{{ sshd_deny_groups }}' }
+    when: vt_control_5_2_14 | bool
+    notify: restart ssh
+    tags:
+      - section5
+      - section5.2
+      - section5.2.14
 
   - name: 5.2.15 Ensure SSH warning banner is configured (Scored)
     lineinfile:

--- a/vt-playbooks/incremental_playbook.yml
+++ b/vt-playbooks/incremental_playbook.yml
@@ -27,34 +27,6 @@
         password: "$6$9ZAG1bxgpq8Z.GO/$MA1JHXB3hOhk.RW2WzRtg0taaUr.YqW6DJKoIc0G1q8.DnSuF/9WTbuL0CZ/fFqqgGTb5NLkOYFlanqCU7T5r1"
       tags: prep
 
-    - name: sshd_allow_users fact
-      set_fact:
-        sshd_allow_users: ubuntu
-
-    - name: sshd_allow_groups fact
-      set_fact:
-        sshd_allow_groups:
-
-    - name: sshd_deny_users fact
-      set_fact:
-        sshd_deny_users:
-
-    - name: sshd_deny_groups fact
-      set_fact:
-        sshd_deny_groups:
-
-    - name: set_bootloader_password fact
-      set_fact:
-        set_bootloader_password: False
-
-    - name: set enable_hosts_allow fact
-      set_fact:
-        enable_hosts_allow: False
-
-    - name: enable_hosts_deny fact
-      set_fact:
-        enable_hosts_deny: True 
-
     - include_tasks: cis-ubuntu-ansible/tasks/section_01.yml
       tags: one
 

--- a/vt-playbooks/modern_playbook.yml
+++ b/vt-playbooks/modern_playbook.yml
@@ -24,12 +24,4 @@
 
     - include_role:
         name: cis
-      vars:
-        sshd_allow_users: ubuntu
-        sshd_allow_groups:
-        sshd_deny_users:
-        sshd_deny_groups:
-        set_bootloader_password: False
-        enable_hosts_allow: False
-        enable_hosts_deny: False
 

--- a/vt-playbooks/workaround_playbook.yml
+++ b/vt-playbooks/workaround_playbook.yml
@@ -20,38 +20,6 @@
         update_password: always
         password: "$6$9ZAG1bxgpq8Z.GO/$MA1JHXB3hOhk.RW2WzRtg0taaUr.YqW6DJKoIc0G1q8.DnSuF/9WTbuL0CZ/fFqqgGTb5NLkOYFlanqCU7T5r1"
 
-    - name: sshd_allow_users fact
-      set_fact:
-        sshd_allow_users: ubuntu
-
-    - name: sshd_allow_groups fact
-      set_fact:
-        sshd_allow_groups:
-
-    - name: sshd_deny_users fact
-      set_fact:
-        sshd_deny_users:
-
-    - name: sshd_deny_groups fact
-      set_fact:
-        sshd_deny_groups:
-
-    - name: set_bootloader_password fact
-      set_fact:
-        set_bootloader_password: False
-
-    - name: set enable_hosts_allow fact
-      set_fact:
-        enable_hosts_allow: False
-
-    - name: set enable_hosts_deny fact
-      set_fact:
-        enable_hosts_deny: False
-
-    - name: set firewall_policy_drop fact
-      set_fact:
-        firewall_policy_drop: False
-
   roles:
     - ../roles/cis
 

--- a/vt-secops-tests/README.md
+++ b/vt-secops-tests/README.md
@@ -1,0 +1,54 @@
+# Running CIS Hardening Monthly
+
+I believe we are just in an OK spot with this for now. I really think we need to replace the Ansible role with something else to move forward by leaps and bounds. It is just hard to allocate the time necessary to do that when we have a tool that works to a degree.
+
+## Role Configuration
+
+See **roles/cis/defaults/main.yml** under the role source code.
+
+The original auther of the role did a decent job of commenting this file so you know which variables belong to which role. You can always reverse this by looking at a tasks file to find the variable and using it to search the defaults file.
+
+### Veritone Custom Variables
+
+There were a few rules that caused us a great deal of angst with Packer and hardening leading up to FedRAMP. To get through FedRAMP, I hacked the file to comment out those rules.
+
+For the monthly runs, I have added custom variables to cover those rules. This way you can flip a boolean to enable/disable a rule vs. commenting out a block of code.
+
+Those variables are:
+
+```yaml
+vt_control_5_2_7: False
+vt_control_5_2_9: False
+vt_control_5_2_14: True
+```
+
+The rules associated with 5.2.7 and 5.2.9 are anathema to our use of Packer and our use of immutable infrastructure. I don't see us ever being compliant with those rules.
+
+We can use 5.2.14 to our advantage. All of the user and group lists in the **roles/cis/defaults/main.yml** file are empty to start. We can then add the Packer user to the users list, enable this rule and only Packer will be able to access the instance.
+
+## Vagrant SSH Test
+
+The number one problem we had when trying to integrate hardening into the Packer builds, was cutting of Packer's SSH access.
+
+This README.md lives in **cis-ubuntu-ansible/vt-secops-tests**. I sense Gary will want that to read infosec as he uses that term for us everywhere. We can fix that as part of the PR.
+
+That directory contains all you need to do an SSH test.
+
+```
+cd vt-secops-tests
+vagrant up
+vagrant ssh
+```
+
+If hardening has broken SSH, you won't be able to SSH as the vagrant user which means Packer won't be able to SSH either.
+
+We will have a much friendlier relationshiop with DevOps if we consistently give them hardening that Packer can access. It doesn't mean the hardening will be perfect out of the box, but at least they won't hit a basic issue to start.
+
+## Other Tests
+
+There are a lot of configuration options in **roles/cis/defaults/main.yml**. This means there are plenty of things you can tweak each month. The risk you run is these are things we won't see with an SSH test. These are the kinds of things the application code will break on.
+
+At some point, we might want to see if we could make this more valuable by testing against n number of applications. I know we don't have a test team at Veritone, yet. When we do, we should probably talk to them about automated testing of the hardening.
+
+What I envision is a smoke test per application. We would stand an application up on the newest hardened AMI, run the smoke test and see what breaks.
+

--- a/vt-secops-tests/Vagrantfile
+++ b/vt-secops-tests/Vagrantfile
@@ -1,0 +1,12 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.network :forwarded_port, guest: 22, host: 2223, id: "ssh"
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "playbook.yml"
+	ansible.inventory_path = "./hosts"
+    ansible.verbose = "-vvv"
+    ansible.limit = "all"
+    ansible.host_key_checking = false
+  end
+end

--- a/vt-secops-tests/ansible.cfg
+++ b/vt-secops-tests/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+retry_files_enabled = False

--- a/vt-secops-tests/hosts
+++ b/vt-secops-tests/hosts
@@ -1,0 +1,4 @@
+localhost ansible_connection=local
+
+[test-monthly]
+test_box ansible_host=127.0.0.1 ansible_port=2223

--- a/vt-secops-tests/playbook.yml
+++ b/vt-secops-tests/playbook.yml
@@ -1,0 +1,15 @@
+---
+
+- name: test hardening
+  hosts: test-monthly
+  become: True
+  
+  pre_tasks:
+
+    - name: set the sshd_allow_users fact
+      set_fact:
+        sshd_allow_users: vagrant
+
+  roles:
+    - ../roles/cis
+


### PR DESCRIPTION
This includes some minor changes to make it easier for infosec to do the hardening monthly.

1. All config for the hardening has been moved to the role defaults file (cis/defaults/main.yml).
2. Added a new directory where infosec can test that the hardening changes did not break SSH. This is done via Vagrant. See the README.md.

@lanmalkieri @veritone/devops 